### PR TITLE
Make makeEnum pass the isConstructorLike test

### DIFF
--- a/can-query-logic-test.js
+++ b/can-query-logic-test.js
@@ -233,3 +233,10 @@ QUnit.test("isPaginated, removePagination", function(assert){
     assert.deepEqual( algebra.removePagination({page: {start: 1, end: 2}}), {}, "removePagination page");
 
 });
+
+QUnit.test("Value returned by makeEnum is constructorLike", function(assert){
+	var Status = QueryLogic.makeEnum(["new", "preparing", "delivery", "delivered"]);
+	var pass = canReflect.isConstructorLike(Status);
+
+	assert.ok(pass, "Status is constructor like");
+});

--- a/can-query-logic.js
+++ b/can-query-logic.js
@@ -5,6 +5,7 @@ var makeBasicQueryConvert = require("./src/serializers/basic-query");
 var BasicQuery = require("./src/types/basic-query");
 var valueComparisons = require("./src/types/comparisons");
 var schemaSymbol = canSymbol.for("can.getSchema");
+var newSymbol = canSymbol.for("can.new");
 var makeEnum = require("./src/types/make-enum");
 
 
@@ -173,6 +174,7 @@ QueryLogic.UNKNOWABLE = set.UNKNOWABLE;
 
 QueryLogic.makeEnum = function(values){
     var Type = function(){};
+		Type[newSymbol] = function(val) { return val; };
     makeEnum(Type, values);
     return Type;
 };


### PR DESCRIPTION
This fixes the issue with not being able to use an enum type as a `Type` or `type` in DefineMap.