### PR TITLE
Make sure hydrate is called within comparisons

### DIFF
--- a/src/serializers/comparisons-test.js
+++ b/src/serializers/comparisons-test.js
@@ -5,28 +5,42 @@ var canReflect = require("can-reflect");
 QUnit.module("can-query-logic/serializers/comparisons");
 
 QUnit.test("hydrate and serialize", function(){
-    var Type = function(value){
-        this.value = value;
-    };
+	var Type = function(value){
+		this.value = value;
+	};
 
-    canReflect.assignSymbols(Type.prototype,{
+	canReflect.assignSymbols(Type.prototype,{
 		"can.serialize": function(){
 			return this.value;
 		}
 	})
 
-    var hydrated = comparisons.hydrate({$in: [1,2]}, function(value){
-        return new Type(value);
-    });
+	var hydrated = comparisons.hydrate({$in: [1,2]}, function(value){
+		return new Type(value);
+	});
 
-    QUnit.deepEqual(hydrated.values, [
-        new Type(1),
-        new Type(2)
-    ], "hydrated");
+	QUnit.deepEqual(hydrated.values, [
+		new Type(1),
+		new Type(2)
+	], "hydrated");
 
-    var serialized = comparisons.serializer.serialize(hydrated);
+	var serialized = comparisons.serializer.serialize(hydrated);
 
-    QUnit.deepEqual(serialized,{
-        $in: [1,2]
-    }, "serialized");
+	QUnit.deepEqual(serialized,{
+		$in: [1,2]
+	}, "serialized");
+});
+
+QUnit.test("unknown hydrator is called in all cases", function(){
+
+	var hydrated = [];
+	var addToHydrated = function(value){
+		hydrated.push(value);
+	}
+
+	comparisons.hydrate({$in: [1,2]}, addToHydrated);
+	comparisons.hydrate("abc", addToHydrated);
+	comparisons.hydrate(["x","y"], addToHydrated);
+
+	QUnit.deepEqual(hydrated, [1,2, "abc","x","y"], "hydrated called with the right stuff");
 });

--- a/src/serializers/comparisons.js
+++ b/src/serializers/comparisons.js
@@ -3,32 +3,32 @@ var Serializer = require("../serializer");
 var canReflect = require("can-reflect");
 
 function makeNew(Constructor) {
-    return function(value){
-        return new Constructor(value);
-    };
+	return function(value){
+		return new Constructor(value);
+	};
 }
 var hydrateMap = {};
 function addHydrateFrom(key, hydrate) {
-    hydrateMap[key] = function(value, unknownHydrator) {
-        return hydrate( unknownHydrator ? unknownHydrator(value[key]) : value[key]);
-    };
-    Object.defineProperty(hydrateMap[key], "name", {
+	hydrateMap[key] = function(value, unknownHydrator) {
+		return hydrate( unknownHydrator ? unknownHydrator(value[key]) : value[key]);
+	};
+	Object.defineProperty(hydrateMap[key], "name", {
 		value: "hydrate "+key,
 		writable: true
 	});
 }
 
 function addHydrateFromValues(key, hydrate) {
-    hydrateMap[key] = function(value, unknownHydrator) {
-        var clones = value[key];
-        if(unknownHydrator) {
-            clones = clones.map(function(value){
-                return unknownHydrator(value);
-            });
-        }
-        return hydrate( clones );
-    };
-    Object.defineProperty(hydrateMap[key], "name", {
+	hydrateMap[key] = function(value, unknownHydrator) {
+		var clones = value[key];
+		if(unknownHydrator) {
+			clones = clones.map(function(value){
+				return unknownHydrator(value);
+			});
+		}
+		return hydrate( clones );
+	};
+	Object.defineProperty(hydrateMap[key], "name", {
 		value: "hydrate "+key,
 		writable: true
 	});
@@ -36,10 +36,10 @@ function addHydrateFromValues(key, hydrate) {
 
 // https://docs.mongodb.com/manual/reference/operator/query-comparison/
 addHydrateFrom("$eq", function(value){
-    return new is.In([value]);
+	return new is.In([value]);
 });
 addHydrateFrom("$ne", function(value){
-    return new is.NotIn([value]);
+	return new is.NotIn([value]);
 });
 
 addHydrateFrom("$gt", makeNew(is.GreaterThan));
@@ -54,68 +54,70 @@ addHydrateFromValues("$nin", makeNew(is.GreaterThan));
 
 
 var serializer = new Serializer([
-    [is.In,function(isIn, serialize){
-        return isIn.values.length === 1 ?
-            serialize(isIn.values[0]) :
-            {$in: isIn.values.map(serialize)};
-    }],
-    [is.NotIn,function(notIn, serialize){
-        return notIn.values.length === 1 ?
-            {$ne: serialize(notIn.values[0])} : {$nin: notIn.values.map(serialize)};
-    }],
-    [is.GreaterThan, function(gt, serialize){ return {$gt: serialize(gt.value) }; }],
-    [is.GreaterThanEqual, function(gte, serialize){ return {$gte: serialize(gte.value) }; }],
-    [is.LessThan, function(lt, serialize){ return {$lt: serialize(lt.value) }; }],
-    [is.LessThanEqual, function(lt, serialize){ return {$lte: serialize(lt.value) }; }],
-    [is.And, function(and, serialize){
-        var obj = {};
-        and.values.forEach(function(clause){
-            canReflect.assignMap(obj, serialize(clause) );
-        });
-        return obj;
-    }]
-    /*[is.Or, function(or, serialize){
-        return {
-            $or: or.values.map(function(value){
-                return serialize(value, serialize);
-            })
-        };
-    }]*/
+	[is.In,function(isIn, serialize){
+		return isIn.values.length === 1 ?
+			serialize(isIn.values[0]) :
+			{$in: isIn.values.map(serialize)};
+	}],
+	[is.NotIn,function(notIn, serialize){
+		return notIn.values.length === 1 ?
+			{$ne: serialize(notIn.values[0])} : {$nin: notIn.values.map(serialize)};
+	}],
+	[is.GreaterThan, function(gt, serialize){ return {$gt: serialize(gt.value) }; }],
+	[is.GreaterThanEqual, function(gte, serialize){ return {$gte: serialize(gte.value) }; }],
+	[is.LessThan, function(lt, serialize){ return {$lt: serialize(lt.value) }; }],
+	[is.LessThanEqual, function(lt, serialize){ return {$lte: serialize(lt.value) }; }],
+	[is.And, function(and, serialize){
+		var obj = {};
+		and.values.forEach(function(clause){
+			canReflect.assignMap(obj, serialize(clause) );
+		});
+		return obj;
+	}]
+	/*[is.Or, function(or, serialize){
+		return {
+			$or: or.values.map(function(value){
+				return serialize(value, serialize);
+			})
+		};
+	}]*/
 ]);
 
 module.exports = {
-    hydrate: function(value, hydrateUnknown){
-        if(!hydrateUnknown) {
-            hydrateUnknown = function(){
-                throw new Error("can-query-logic doesn't recognize operator: "+JSON.stringify(value));
-            }
-        }
-        if(Array.isArray(value)) {
-            return new is.In(value);
-        }
-        else if(value && typeof value === "object") {
-            var keys = Object.keys(value);
-            var allKeysAreComparisons = keys.every(function(key){
-                return hydrateMap[key]
-            })
-            if(allKeysAreComparisons) {
-                var andClauses = keys.map(function(key){
-                    var part = {};
-                    part[key] = value[key];
-                    var hydrator = hydrateMap[key];
-                    return hydrator(part, hydrateUnknown);
-                });
-                if(andClauses.length > 1) {
-                    return new is.And(andClauses);
-                } else {
-                    return andClauses[0];
-                }
-            } else {
-                return hydrateUnknown(value);
-            }
-        } else {
-            return new is.In([value]);
-        }
-    },
-    serializer: serializer
+	hydrate: function(value, hydrateUnknown){
+		if(!hydrateUnknown) {
+			hydrateUnknown = function(){
+				throw new Error("can-query-logic doesn't recognize operator: "+JSON.stringify(value));
+			}
+		}
+		if(Array.isArray(value)) {
+			return new is.In(value.map(function(value){
+				return hydrateUnknown(value);
+			}));
+		}
+		else if(value && typeof value === "object") {
+			var keys = Object.keys(value);
+			var allKeysAreComparisons = keys.every(function(key){
+				return hydrateMap[key]
+			});
+			if(allKeysAreComparisons) {
+				var andClauses = keys.map(function(key){
+					var part = {};
+					part[key] = value[key];
+					var hydrator = hydrateMap[key];
+					return hydrator(part, hydrateUnknown);
+				});
+				if(andClauses.length > 1) {
+					return new is.And(andClauses);
+				} else {
+					return andClauses[0];
+				}
+			} else {
+				return hydrateUnknown(value);
+			}
+		} else {
+			return new is.In([hydrateUnknown(value)]);
+		}
+	},
+	serializer: serializer
 };

--- a/test/maybe-type-test.js
+++ b/test/maybe-type-test.js
@@ -5,160 +5,168 @@ var canReflect = require("can-reflect");
 QUnit.module("can-query-logic with maybe type");
 
 QUnit.test("basics", function(){
-    // Goal here is so the type doesn't have to know about `can-query-logic`,
-    // but when passed to can-query-logic, it knows what to do.
-    //
+	// Goal here is so the type doesn't have to know about `can-query-logic`,
+	// but when passed to can-query-logic, it knows what to do.
+	//
 
-    var MaybeNumber = canReflect.assignSymbols({},{
-        "can.new": function(val){
-            if (val == null) {
-    			return val;
-    		}
-    		return +(val);
-        },
-        "can.getSchema": function(){
-            return {
-                type: "Or",
-                values: [Number, undefined, null]
-            };
-        }
-    });
+	var MaybeNumber = canReflect.assignSymbols({},{
+		"can.new": function(val){
+			if (val == null) {
+				return val;
+			}
+			return +(val);
+		},
+		"can.getSchema": function(){
+			return {
+				type: "Or",
+				values: [Number, undefined, null]
+			};
+		}
+	});
 
-    var res;
+	var res;
 
-    var todoQueryLogic = new QueryLogic({
-        keys: {
-            age: MaybeNumber
-        }
-    });
+	var todoQueryLogic = new QueryLogic({
+		keys: {
+			age: MaybeNumber
+		}
+	});
+	/*
+	res = todoQueryLogic.difference(
+		{},
+		{filter: {age: {$gt: 5}}});
 
-    res = todoQueryLogic.difference(
-        {},
-        {filter: {age: {$gt: 5}}});
+	QUnit.deepEqual(res.filter,
+		{$or: [
+			{age: {$lte: 5} },
+			{age: {$in: [undefined, null]}}
+		]},
+		"difference works");
 
-    QUnit.deepEqual(res.filter,
-        {$or: [
-            {age: {$lte: 5} },
-            {age: {$in: [undefined, null]}}
-        ]},
-        "difference works");
+	var query = todoQueryLogic.hydrate({filter: {age: 21}});
 
-    var query = todoQueryLogic.hydrate({filter: {age: 21}});
+	var serialized = todoQueryLogic.serialize(query);
+	QUnit.deepEqual( serialized, {filter: {age: 21}}, "can serialize back to what was provided" );
 
-    var serialized = todoQueryLogic.serialize(query);
-    QUnit.deepEqual( serialized, {filter: {age: 21}}, "can serialize back to what was provided" );
+	res = todoQueryLogic.difference({},{
+		filter: {
+			age: {
+				$gt: 3,
+				$lt: 7
+			}
+		}
+	});
 
-    res = todoQueryLogic.difference({},{
-        filter: {
-            age: {
-                $gt: 3,
-                $lt: 7
-            }
-        }
-    });
+	QUnit.deepEqual(res.filter,
+		{$or: [
+			{age: {$gte: 7} },
+			{age: {$lte: 3} },
+			{age: {$in: [undefined, null]}}
+		]});*/
 
-    QUnit.deepEqual(res.filter,
-        {$or: [
-            {age: {$gte: 7} },
-            {age: {$lte: 3} },
-            {age: {$in: [undefined, null]}}
-        ]});
+
+	var unionized = todoQueryLogic.union(
+		{filter: {age: 7}},
+		{filter: {age: "07"}}
+	);
+
+	QUnit.deepEqual(unionized, {filter: {age: 7}}, "string numbers are converted to numbers");
 
 });
 
 
 QUnit.test("MaybeDate", function(){
-    // Goal here is so the type doesn't have to know about `can-query-logic`,
-    // but when passed to can-query-logic, it knows what to do.
-    function toDate(str) {
-        var type = typeof str;
-        if (type === 'string') {
-            str = Date.parse(str);
-            return isNaN(str) ? null : new Date(str);
-        } else if (type === 'number') {
-            return new Date(str);
-        } else {
-            return str;
-        }
-    }
+	// Goal here is so the type doesn't have to know about `can-query-logic`,
+	// but when passed to can-query-logic, it knows what to do.
+	function toDate(str) {
+		var type = typeof str;
+		if (type === 'string') {
+			str = Date.parse(str);
+			return isNaN(str) ? null : new Date(str);
+		} else if (type === 'number') {
+			return new Date(str);
+		} else {
+			return str;
+		}
+	}
 
-    function DateStringSet(dateStr){
-        this.setValue = dateStr;
-        var date = toDate(dateStr);
-        this.value = date == null ? date : date.getTime();
-    }
+	function DateStringSet(dateStr){
+		this.setValue = dateStr;
+		var date = toDate(dateStr);
+		this.value = date == null ? date : date.getTime();
+	}
 
-    DateStringSet.prototype.valueOf = function(){
-        return this.value;
-    };
-    canReflect.assignSymbols(DateStringSet.prototype,{
-        "can.serialize": function(){
-            return this.setValue;
-        }
-    });
+	DateStringSet.prototype.valueOf = function(){
+		return this.value;
+	};
+	canReflect.assignSymbols(DateStringSet.prototype,{
+		"can.serialize": function(){
+			return this.setValue;
+		}
+	});
 
-    var MaybeDate = canReflect.assignSymbols({},{
-        "can.new": toDate,
-        "can.getSchema": function(){
-            return {
-                type: "Or",
-                values: [Date, undefined, null]
-            };
-        },
-        "can.ComparisonSetType": DateStringSet
-    });
+	var MaybeDate = canReflect.assignSymbols({},{
+		"can.new": toDate,
+		"can.getSchema": function(){
+			return {
+				type: "Or",
+				values: [Date, undefined, null]
+			};
+		},
+		"can.ComparisonSetType": DateStringSet
+	});
 
-    var res;
+	var res;
 
-    var todoQueryLogic = new QueryLogic({
-        keys: {
-            due: MaybeDate
-        }
-    });
+	var todoQueryLogic = new QueryLogic({
+		keys: {
+			due: MaybeDate
+		}
+	});
 
-    var date1982_10_20 = new Date(1982,9,20).toString();
+	var date1982_10_20 = new Date(1982,9,20).toString();
 
-    res = todoQueryLogic.difference(
-        {},
-        {filter: {due: {$gt: date1982_10_20}}});
+	res = todoQueryLogic.difference(
+		{},
+		{filter: {due: {$gt: date1982_10_20}}});
 
-    QUnit.deepEqual(res.filter,
-        {$or: [
-            {due: {$lte: date1982_10_20} },
-            {due: {$in: [undefined, null]}}
-        ]},
-        "difference works");
+	QUnit.deepEqual(res.filter,
+		{$or: [
+			{due: {$lte: date1982_10_20} },
+			{due: {$in: [undefined, null]}}
+		]},
+		"difference works");
 
-    var gt1982 = {filter: {due: {$gt: date1982_10_20}}};
+	var gt1982 = {filter: {due: {$gt: date1982_10_20}}};
 
-    QUnit.ok( todoQueryLogic.isMember(gt1982,{
-        id: 0,
-        due: new Date(2000,0,1)
-    }), "works with a date object");
+	QUnit.ok( todoQueryLogic.isMember(gt1982,{
+		id: 0,
+		due: new Date(2000,0,1)
+	}), "works with a date object");
 
-    QUnit.ok( todoQueryLogic.isMember(gt1982,{
-        id: 0,
-        due: new Date(2000,0,1).toString()
-    }), "works with a string date");
+	QUnit.ok( todoQueryLogic.isMember(gt1982,{
+		id: 0,
+		due: new Date(2000,0,1).toString()
+	}), "works with a string date");
 
-    QUnit.ok( todoQueryLogic.isMember(gt1982,{
-        id: 0,
-        due: new Date(2000,0,1).getTime()
-    }), "works with a integer date");
+	QUnit.ok( todoQueryLogic.isMember(gt1982,{
+		id: 0,
+		due: new Date(2000,0,1).getTime()
+	}), "works with a integer date");
 
-    QUnit.notOk( todoQueryLogic.isMember(gt1982,{
-        id: 0,
-        due: new Date(1970,0,1).getTime()
-    }), "doesn't fail if falsey");
+	QUnit.notOk( todoQueryLogic.isMember(gt1982,{
+		id: 0,
+		due: new Date(1970,0,1).getTime()
+	}), "doesn't fail if falsey");
 
-    QUnit.notOk( todoQueryLogic.isMember(gt1982,{
-        id: 0,
-        due: null
-    }), "doesn't fail if falsey");
+	QUnit.notOk( todoQueryLogic.isMember(gt1982,{
+		id: 0,
+		due: null
+	}), "doesn't fail if falsey");
 
-    QUnit.ok( todoQueryLogic.isMember({filter: {due: {$in: [null,undefined]}}},{
-        id: 0,
-        due: null
-    }), "works if using in");
+	QUnit.ok( todoQueryLogic.isMember({filter: {due: {$in: [null,undefined]}}},{
+		id: 0,
+		due: null
+	}), "works if using in");
 
 });

--- a/test/special-comparison-logic-test.js
+++ b/test/special-comparison-logic-test.js
@@ -6,155 +6,155 @@ QUnit.module("can-query-logic special comparison logic");
 
 QUnit.test("where to filter", function(){
 
-    var todoQueryLogic = new QueryLogic({}, {
-        toQuery(params){
-            var where = params.where;
-            delete params.where;
-            params.filter = where;
-            return params;
-        },
-        toParams(query){
-            var where = query.filter;
-            delete query.filter;
-            query.where = where;
-            return query;
-        }
-    });
-    var q1 = {
-            where: {first: "FIRST"}
-        },
-        q2 = {
-            where: {second: "SECOND"}
-        };
+	var todoQueryLogic = new QueryLogic({}, {
+		toQuery(params){
+			var where = params.where;
+			delete params.where;
+			params.filter = where;
+			return params;
+		},
+		toParams(query){
+			var where = query.filter;
+			delete query.filter;
+			query.where = where;
+			return query;
+		}
+	});
+	var q1 = {
+			where: {first: "FIRST"}
+		},
+		q2 = {
+			where: {second: "SECOND"}
+		};
 
-    var q3 = todoQueryLogic.intersection(q1,q2);
+	var q3 = todoQueryLogic.intersection(q1,q2);
 
-    QUnit.deepEqual(q3,{
-        where: {first: "FIRST", second: "SECOND"}
-    }, "got intersection");
+	QUnit.deepEqual(q3,{
+		where: {first: "FIRST", second: "SECOND"}
+	}, "got intersection");
 });
 
 QUnit.test("Searchable string", function(){
-    // Create a set type that is used to do comparisons.
-    function SearchableStringSet(value) {
-        this.value = value;
-    }
+	// Create a set type that is used to do comparisons.
+	function SearchableStringSet(value) {
+		this.value = value;
+	}
 
-    canReflect.assignSymbols(SearchableStringSet.prototype,{
-        // Returns if the name on a todo is actually a member of the set.
-        "can.isMember": function(value){
-            return value.includes(this.value);
-        },
-        "can.serialize": function(){
-            return this.value;
-        }
-    });
+	canReflect.assignSymbols(SearchableStringSet.prototype,{
+		// Returns if the name on a todo is actually a member of the set.
+		"can.isMember": function(value){
+			return value.includes(this.value);
+		},
+		"can.serialize": function(){
+			return this.value;
+		}
+	});
 
-    // Specify how to do the fundamental set comparisons.
-    QueryLogic.defineComparison(SearchableStringSet,SearchableStringSet,{
-        union(searchA, searchB){
-            if(searchA.value.includes(searchB.value)) {
-                return searchB;
-            }
-            if(searchB.value.includes(searchA.value)) {
-                return searchA;
-            }
-            return new QueryLogic.ValuesOr([searchA, searchB]);
-        },
-        // a aa
-        intersection(searchA, searchB){
-            if(searchA.value.includes(searchB.value)) {
-                return searchA;
-            }
-            if(searchB.value.includes(searchA.value)) {
-                return searchB;
-            }
-            return QueryLogic.UNDEFINABLE;
-        },
-        difference(searchA, searchB){
-            // if a is a subset
-            if(searchA.value.includes(searchB.value)) {
-                return QueryLogic.EMPTY;
-            }
-            // a is a superset
-            if(searchB.value.includes(searchA.value)) {
-                return QueryLogic.UNDEFINABLE;
-            }
-            // foo \ bar
-            return QueryLogic.UNDEFINABLE;
-        }
-    });
+	// Specify how to do the fundamental set comparisons.
+	QueryLogic.defineComparison(SearchableStringSet,SearchableStringSet,{
+		union(searchA, searchB){
+			if(searchA.value.includes(searchB.value)) {
+				return searchB;
+			}
+			if(searchB.value.includes(searchA.value)) {
+				return searchA;
+			}
+			return new QueryLogic.ValuesOr([searchA, searchB]);
+		},
+		// a aa
+		intersection(searchA, searchB){
+			if(searchA.value.includes(searchB.value)) {
+				return searchA;
+			}
+			if(searchB.value.includes(searchA.value)) {
+				return searchB;
+			}
+			return QueryLogic.UNDEFINABLE;
+		},
+		difference(searchA, searchB){
+			// if a is a subset
+			if(searchA.value.includes(searchB.value)) {
+				return QueryLogic.EMPTY;
+			}
+			// a is a superset
+			if(searchB.value.includes(searchA.value)) {
+				return QueryLogic.UNDEFINABLE;
+			}
+			// foo \ bar
+			return QueryLogic.UNDEFINABLE;
+		}
+	});
 
-    // Alternate comparisons
-    /*QueryLogic.defineComparison(SearchableStringSet,SearchableStringSet,{
-        isSubset(searchA, searchB){
-            return searchA.value.includes(searchB.value);
-        }
-    });*/
+	// Alternate comparisons
+	/*QueryLogic.defineComparison(SearchableStringSet,SearchableStringSet,{
+		isSubset(searchA, searchB){
+			return searchA.value.includes(searchB.value);
+		}
+	});*/
 
-    // The type specified doesn't do anything here.
-    // Sometimes it might be used for creating the actual value on
-    // a Todo. That's why it's only used for a reference ot the
-    // actual set type.
-    function SearchableString(){
+	// The type specified doesn't do anything here.
+	// Sometimes it might be used for creating the actual value on
+	// a Todo. That's why it's only used for a reference ot the
+	// actual set type.
+	function SearchableString(){
 
-    }
+	}
 
-    SearchableString[Symbol.for("can.SetType")] = SearchableStringSet;
+	SearchableString[Symbol.for("can.SetType")] = SearchableStringSet;
 
-    var todoQueryLogic = new QueryLogic({
-        keys: {
-            name: SearchableString
-        }
-    });
+	var todoQueryLogic = new QueryLogic({
+		keys: {
+			name: SearchableString
+		}
+	});
 
-    var res = todoQueryLogic.isSubset({
-        filter: {name: "beat"}
-    },{
-        filter: {name: "eat"}
-    });
+	var res = todoQueryLogic.isSubset({
+		filter: {name: "beat"}
+	},{
+		filter: {name: "eat"}
+	});
 
-    QUnit.equal(res, true, "is subset");
+	QUnit.equal(res, true, "is subset");
 
-    res = todoQueryLogic.isSubset({
-        filter: {name: "eat"}
-    },{
-        filter: {name: "beat"}
-    });
+	res = todoQueryLogic.isSubset({
+		filter: {name: "eat"}
+	},{
+		filter: {name: "beat"}
+	});
 
-    QUnit.equal(res, false, "not subset");
+	QUnit.equal(res, false, "not subset");
 
-    var hydrated = todoQueryLogic.hydrate({
-        filter: {name: "eat"}
-    });
+	var hydrated = todoQueryLogic.hydrate({
+		filter: {name: "eat"}
+	});
 
-    QUnit.deepEqual(hydrated.filter, new QueryLogic.KeysAnd({
-        name: new SearchableStringSet("eat")
-    }), "hydrated right");
+	QUnit.deepEqual(hydrated.filter, new QueryLogic.KeysAnd({
+		name: new SearchableStringSet("eat")
+	}), "hydrated right");
 
-    res = todoQueryLogic.union({
-        filter: {name: "eat"}
-    },{
-        filter: {name: "foo"}
-    });
+	res = todoQueryLogic.union({
+		filter: {name: "eat"}
+	},{
+		filter: {name: "foo"}
+	});
 
-    QUnit.deepEqual(res, {
-        filter: {
-            name: ["eat","foo"]
-        }
-    });
+	QUnit.deepEqual(res, {
+		filter: {
+			name: ["eat","foo"]
+		}
+	});
 
-    QUnit.ok(
-        todoQueryLogic.isMember({
-            filter: {name: "eat"}
-        },{id: 1, name: "eat beans"}),
-        "isMember true");
+	QUnit.ok(
+		todoQueryLogic.isMember({
+			filter: {name: "eat"}
+		},{id: 1, name: "eat beans"}),
+		"isMember true");
 
-    QUnit.notOk(
-        todoQueryLogic.isMember({
-            filter: {name: "eat"}
-        },{id: 1, name: "foo bar"}),
-        "isMember false");
+	QUnit.notOk(
+		todoQueryLogic.isMember({
+			filter: {name: "eat"}
+		},{id: 1, name: "foo bar"}),
+		"isMember false");
 
 });
 
@@ -162,98 +162,99 @@ QUnit.test("value type", function(){
 
 
 
-    function DateStringSet(dateStr){
+	function DateStringSet(dateStr){
 
-        this.dateStr = dateStr;
-    }
+		this.dateStr = dateStr;
+	}
 
-    DateStringSet.prototype.valueOf = function(){
-        return new Date(this.dateStr).valueOf();
-    };
-    canReflect.assignSymbols(DateStringSet,{
-        "can.serialize": function(){
-            return this.dateStr;
-        }
-    });
+	DateStringSet.prototype.valueOf = function(){
+		return new Date(this.dateStr).valueOf();
+	};
+	canReflect.assignSymbols(DateStringSet.prototype,{
+		"can.serialize": function(){
+			return this.dateStr;
+		}
+	});
 
-    function DateString(){
+	function DateString(){
 
-    }
+	}
 
-    canReflect.assignSymbols(DateString,{
-        "can.SetType": DateStringSet
-    });
-
-
-
-    var queryLogic = new QueryLogic({
-        keys: {
-            date: DateString
-        }
-    });
-
-    var oct20_1982 = new Date(1982,9,20),
-        date90s = new Date(1990,0,1);
-
-    // new And({
-    //   date: new GT( new DateStringSet("string") )
-    // })
-    // The problem is that GT is going to test
-    //    `new DateStringSet("10-20") > "10-20"
-    // How do we indicate that these tests should use the underlying type "converter"?
-    //  - seems like not a great idea to use the `this.value` type to wrap the property value.
-    //  - Can't really call `isMember` b/c
-    //  - could just pass a serialize / hydrate thing ..
-    //
-    var result = queryLogic.filterMembers({
-        filter: {date: {$gt: oct20_1982.toString()}}
-    },[
-        {id: 1, date: new Date(1981,9,20).toString()},
-        {id: 2, date: new Date(1982,9,20).toString()},
-        {id: 3, date: new Date(1983,9,20).toString()},
-        {id: 4, date: new Date(1984,9,20).toString()},
-    ]);
-
-    QUnit.deepEqual(
-        result.map(function(item){ return item.id;}),
-        [3,4],
-        "filtered correctly");
+	canReflect.assignSymbols(DateString,{
+		"can.SetType": DateStringSet
+	});
 
 
-    var union = queryLogic.union({
-        filter: {date: [oct20_1982.toString()]}
-    },{
-        filter: {date: [date90s.toString()]}
-    });
 
-    QUnit.deepEqual(union,
-        {
-            filter: {date: {$in: [oct20_1982.toString(), date90s.toString()]}}
-        }
-    );
+	var queryLogic = new QueryLogic({
+		keys: {
+			date: DateString
+		}
+	});
 
-    var result = queryLogic.filterMembers({
-        sort: "date"
-    },[
-        {id: 2, date: new Date(1982,9,20).toString()},
-        {id: 1, date: new Date(1981,9,20).toString()},
-        {id: 4, date: new Date(1984,9,20).toString()},
-        {id: 3, date: new Date(1983,9,20).toString()}
-    ]);
+	var oct20_1982 = new Date(1982,9,20),
+		date90s = new Date(1990,0,1);
 
-    var ids = result.map(function(item){ return item.id});
-    QUnit.deepEqual(ids,[1,2,3,4], "sorted correctly");
+	// new And({
+	//   date: new GT( new DateStringSet("string") )
+	// })
+	// The problem is that GT is going to test
+	//	`new DateStringSet("10-20") > "10-20"
+	// How do we indicate that these tests should use the underlying type "converter"?
+	//  - seems like not a great idea to use the `this.value` type to wrap the property value.
+	//  - Can't really call `isMember` b/c
+	//  - could just pass a serialize / hydrate thing ..
+	//
+	var result = queryLogic.filterMembers({
+		filter: {date: {$gt: oct20_1982.toString()}}
+	},[
+		{id: 1, date: new Date(1981,9,20).toString()},
+		{id: 2, date: new Date(1982,9,20).toString()},
+		{id: 3, date: new Date(1983,9,20).toString()},
+		{id: 4, date: new Date(1984,9,20).toString()},
+	]);
 
-    var index = queryLogic.index({
-            sort: "date"
-        },
-        [
-            {id: 1, date: new Date(2018,4,20).toString()}, // M
-            {id: 2, date: new Date(2018,4,21).toString()}, // Tu
-            {id: 3, date: new Date(2018,4,22).toString()}, // We
-            {id: 4, date: new Date(2018,4,23).toString()}  // Thurs
-        ],
-        {id: 4, date: new Date(2018,4,24).toString()}); //F
+	QUnit.deepEqual(
+		result.map(function(item){ return item.id;}),
+		[3,4],
+		"filtered correctly");
 
-    QUnit.equal(index, 4, "added at the end")
+
+	var union = queryLogic.union({
+		filter: {date: [oct20_1982.toString()]}
+	},{
+		filter: {date: [date90s.toString()]}
+	});
+
+	QUnit.deepEqual(union,
+		{
+			filter: {date: {$in: [oct20_1982.toString(), date90s.toString()]}}
+		},
+		"union of 2 dates works correctly"
+	);
+
+	result = queryLogic.filterMembers({
+		sort: "date"
+	},[
+		{id: 2, date: new Date(1982,9,20).toString()},
+		{id: 1, date: new Date(1981,9,20).toString()},
+		{id: 4, date: new Date(1984,9,20).toString()},
+		{id: 3, date: new Date(1983,9,20).toString()}
+	]);
+
+	var ids = result.map(function(item){ return item.id});
+	QUnit.deepEqual(ids,[1,2,3,4], "sorted correctly");
+
+	var index = queryLogic.index({
+			sort: "date"
+		},
+		[
+			{id: 1, date: new Date(2018,4,20).toString()}, // M
+			{id: 2, date: new Date(2018,4,21).toString()}, // Tu
+			{id: 3, date: new Date(2018,4,22).toString()}, // We
+			{id: 4, date: new Date(2018,4,23).toString()}  // Thurs
+		],
+		{id: 4, date: new Date(2018,4,24).toString()}); //F
+
+	QUnit.equal(index, 4, "added at the end")
 });


### PR DESCRIPTION
fixes #19 

comparisons are something like `{$gt: 5}`, those need to get converted to `new GreaterThan(5)`.  This happens in comparisons.hydrate().

```js
comparisons.hydrate({$gt: 5}, unknown) //-> new GreaterThan(5)
```

What's supposed to happen, is that the 5 can be converted to `new MaybeNumberSet(5)`. So something like this should happen:




```js
comparisons.hydrate({$gt: 5}, hydrateUnknownType) //-> new GreaterThan(new MaybeNumberSet(5))
```

the `hydrateUnknownType` is used to convert `5` to `new MaybeNumberSet(5)`.  It wasn't be called if hydrate was called like:


```js
comparisons.hydrate(5, hydrateUnknownType) //-> new In([new MaybeNumberSet(5)])
```

or

```js
comparisons.hydrate([5,6], hydrateUnknownType) //-> new In([new MaybeNumberSet(5), new MaybeNumberSet(6)])
```

