### PR TITLE
Add can-log dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "can-assign": "^1.1.1",
     "can-define-lazy-value": "^1.0.2",
     "can-key": "<2.0.0",
+    "can-log": "^1.0.0",
     "can-reflect": "^1.14.1",
     "can-symbol": "^1.6.1"
   },


### PR DESCRIPTION
Formally adds this dependency. Does not bump the version, however, since I can't publish to NPM anyway.