### PR TITLE
fix serializer Map instantiation for IE11

### DIFF
--- a/src/serializer.js
+++ b/src/serializer.js
@@ -1,7 +1,13 @@
 var canReflect = require("can-reflect");
 
 var Serializer = function(entries){
-    this.serializers = new Map(entries || []);
+	var serializers = this.serializers = new Map();
+	if (entries) {
+		canReflect.each(entries, function(entry) {
+			var key = entry[0], value = entry[1];
+			serializers.set(key, value);
+		});
+	}
     this.serialize = this.serialize.bind(this);
 };
 Serializer.prototype.add = function(serializers){


### PR DESCRIPTION
This fixes IE11 compatibility by instantiating `Map` without iterable.