### PR TITLE
fix the code of date string example

### DIFF
--- a/doc/examples/date-string-example.js
+++ b/doc/examples/date-string-example.js
@@ -8,15 +8,13 @@ class DateStringSet {
 	valueOf(){
 		return new Date(this.value).getTime();
 	}
+	[Symbol.for("can.serialize")](){
+        return this.value;
+    }
 }
 
-canReflect.assignSymbols(DateStringSet.prototype,{
-	"can.serialize": function(){
-		return this.value;
-	}
-});
-
 const DateString = {
+	[Symbol.for("can.new")]: function(v){ return v; },
 	[Symbol.for("can.SetType")]: DateStringSet
 };
 
@@ -30,13 +28,13 @@ const queryLogic = new QueryLogic(Todo);
 
 const filter = queryLogic.filterMembers(
 	{filter: {date: {$gt: "Wed Apr 04 2018 10:00:00 GMT-0500 (CDT)"}}},
-	[{id: 1, name: "grab coffee", date: "Wed Apr 03 2018 10:00:00 GMT-0500 (CDT)"},
-	{id: 2, name: "finish these docs", date: "Thurs Apr 05 2018 10:00:00 GMT-0500 (CDT)"},
-	{id: 3, name: "Learn CanJS", date: "Thurs Apr 05 2017 10:00:00 GMT-0500 (CDT)"}]
-); 
+	[{id: 1, name: "Learn CanJS", date: "Thurs Apr 05 2017 10:00:00 GMT-0500 (CDT)"},
+	{id: 2, name: "grab coffee", date: "Wed Apr 03 2018 10:00:00 GMT-0500 (CDT)"},
+	{id: 3, name: "finish these docs", date: "Thurs Apr 05 2018 10:00:00 GMT-0500 (CDT)"}]
+);
 
-console.log(filter); //-> {
+console.log(filter); //-> [{
 // 	id: 2,
 // 	name: "finish these docs",
 // 	date: "Wed Apr 05 2018 10:00:00 GMT-0500 (CDT)"
-// }
+// }]


### PR DESCRIPTION
Fixes #30 

### The issue:
[date-string-example.js](https://github.com/canjs/can-query-logic/blob/master/doc/examples/date-string-example.js) is broken on codepen, it returns an empty array instead of an array with one object which is the result of the comparaison.

### The changes:
- Add `can.new` Symbol to ```DateString``` Type
- Re-order the list of values to be filtered by date 
