### PR TITLE
add fix .isDefinedAndHasMembers

### DIFF
--- a/src/set-test.js
+++ b/src/set-test.js
@@ -16,3 +16,9 @@ QUnit.test(".ownAndMemberValue", function(){
 		member: "1"
 	}, "{null} and '1'");
 });
+
+QUnit.test(".isDefinedAndHasMembers", function(){
+	QUnit.equal(set.isDefinedAndHasMembers({}), true);
+	QUnit.equal(set.isDefinedAndHasMembers(set.UNIVERSAL), true);
+	QUnit.equal(set.isDefinedAndHasMembers(set.UNDEFINABLE), false);
+});

--- a/src/set.js
+++ b/src/set.js
@@ -172,7 +172,7 @@ set = {
 	},
 	isDefinedAndHasMembers: function(setA) {
 		if (setA !== set.EMPTY && setA !== set.UNDEFINABLE && setA !== set.UNKNOWABLE) {
-			return setA;
+			return !!setA;
 		} else {
 			return false;
 		}


### PR DESCRIPTION
fixes #22 

### How this was fixed:

- Add the failing test
- Fix the function [```isDefinedAndHasMembers```](https://github.com/canjs/can-query-logic/blob/master/src/set.js#L173) in ```set``` module to return ```true``` instead of the value.
