### PR TITLE
Fix helpers.index

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -60,8 +60,10 @@ var helpers = {
 		} else if (compare(props, items[items.length - 1]) === 1) {
 			return items.length;
 		}
+
 		var low = 0,
-			high = items.length;
+			high = items.length,
+			range = [];
 
 		// From lodash lodash 4.6.1 <https://lodash.com/>
 		// Copyright 2012-2016 The Dojo Foundation <http://dojofoundation.org/>
@@ -69,10 +71,24 @@ var helpers = {
 			var mid = (low + high) >>> 1,
 				item = items[mid],
 				computed = compare(props, item);
-			if (computed === -1) {
+			
+			if (computed === 0) {
+				range.push(item);
+				low++;
+			} else if (computed === -1) {
 				high = mid;
 			} else {
 				low = mid + 1;
+			}
+		}
+		if (range.length > 0) {
+			for (var i = 0; i < range.length; i++) {
+				var itemInRange = range[i],
+					id = canReflect.getSchema(itemInRange).identity;
+				if (canReflect.hasOwnKey(props, id) && props[id] === itemInRange[id]) {
+					high = items.indexOf(itemInRange);
+					break;
+				}	
 			}
 		}
 		return high;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -84,7 +84,7 @@ var helpers = {
 		if (range.length > 0) {
 			for (var i = 0; i < range.length; i++) {
 				var itemInRange = range[i],
-					id = canReflect.getSchema(itemInRange).identity;
+					id = canReflect.getSchema(itemInRange).identity[0];
 				if (canReflect.hasOwnKey(props, id) && props[id] === itemInRange[id]) {
 					high = items.indexOf(itemInRange);
 					break;

--- a/src/types/basic-query-sorting-test.js
+++ b/src/types/basic-query-sorting-test.js
@@ -356,3 +356,22 @@ QUnit.test("index uses can-reflect", function(){
     QUnit.deepEqual([obj1Read, obj2Read, itemKeyRead, itemOwnKeyRead],
         [true, true, true, true], "read everything");
 });
+
+
+QUnit.test("index should not sort unchanged items #33", function(assert) {
+	var items = [
+		{id: 1, name: "Item 1"},
+		{id: 2, name: "Item 1"},
+		{id: 3, name: "Item 1"},
+		{id: 4, name: "Item 1"},
+		{id: 5, name: "Item 1"}
+	];
+
+	var query = new BasicQuery({
+        sort: "name"
+	});
+	
+	var res = query.index({id:4, name: "Item 1"}, items);
+
+	QUnit.equal(res, 4);
+});

--- a/src/types/basic-query-sorting-test.js
+++ b/src/types/basic-query-sorting-test.js
@@ -359,13 +359,43 @@ QUnit.test("index uses can-reflect", function(){
 
 
 QUnit.test("index should not sort unchanged items #33", function(assert) {
+	canReflect.assignSymbols({},{
+		"can.getSchema": function() {
+			return {
+				type: "map",
+				identity: ["id"],
+				keys: {
+					id: Number,
+					name: String
+				}
+			};
+		}
+	});
+	
 	var items = [
-		{id: 1, name: "Item 1"},
+		{id: 1, name: "Item 0"},
 		{id: 2, name: "Item 1"},
 		{id: 3, name: "Item 1"},
 		{id: 4, name: "Item 1"},
-		{id: 5, name: "Item 1"}
+		{id: 5, name: "Item 2"}
 	];
+
+	canReflect.eachIndex(items, function(item, i) {
+		canReflect.assignSymbols(item, {
+			"can.getSchema": function() {
+				return {
+					type: "map",
+					identity: ["id"],
+					keys: {
+						id: Number,
+						name: String
+					}
+				};
+			}
+		});
+	});
+
+
 
 	var query = new BasicQuery({
         sort: "name"
@@ -373,5 +403,5 @@ QUnit.test("index should not sort unchanged items #33", function(assert) {
 	
 	var res = query.index({id:4, name: "Item 1"}, items);
 
-	QUnit.equal(res, 4);
+	QUnit.equal(res, 3);
 });


### PR DESCRIPTION
Fixes #33 

### The changes:
Update binary search for `query.index` to return a range of items when the comparator `returns 0` in order to return the index of item for a given identity.