### PR TITLE
Fix query sorting schema issue

### DIFF
--- a/src/helpers-test.js
+++ b/src/helpers-test.js
@@ -94,26 +94,9 @@ QUnit.test("Missed schema on helper.getIndex #45", function() {
 		{id: 4, name: "Item 3"},
 		{id: 5, name: "Item 4"}
 	];
-
-	canReflect.eachIndex(items, function(item) {
-		canReflect.assignSymbols(item, {
-			"can.getSchema": function() {
-				return {
-					type: "map",
-					identity: ["id"],
-					keys: {
-						id: Number,
-						name: String
-					}
-				};
-			}
-		});
-	});
 	
 	var compare = helpers.sorter("name", {});
-	var schema = canReflect.getSchema(items[0]);
+	var schema = { keys: {}, identity: ["id"] };
 	
 	QUnit.equal(helpers.getIndex(compare,items, {id: 2, name: "Item 1"}, schema), 1);
-
-
 });

--- a/src/helpers-test.js
+++ b/src/helpers-test.js
@@ -85,3 +85,35 @@ QUnit.test(".getIndex should not sort unchanged items #33", function() {
 	QUnit.equal(res3, 2);
 	QUnit.equal(res4, 3);
 });
+
+QUnit.test("Missed schema on helper.getIndex #45", function() {
+	var items = [
+		{id: 1, name: "Item 0"},
+		{id: 2, name: "Item 1"},
+		{id: 3, name: "Item 2"},
+		{id: 4, name: "Item 3"},
+		{id: 5, name: "Item 4"}
+	];
+
+	canReflect.eachIndex(items, function(item) {
+		canReflect.assignSymbols(item, {
+			"can.getSchema": function() {
+				return {
+					type: "map",
+					identity: ["id"],
+					keys: {
+						id: Number,
+						name: String
+					}
+				};
+			}
+		});
+	});
+	
+	var compare = helpers.sorter("name", {});
+	var schema = canReflect.getSchema(items[0]);
+	
+	QUnit.equal(helpers.getIndex(compare,items, {id: 2, name: "Item 1"}, schema), 1);
+
+
+});

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -55,22 +55,22 @@ var helpers = {
 	// or in the left direction
 	// otherwise return the last index
 	// see getIdentityIndexByDirection
-	getIdentityIndex: function(compare, items, props, startIndex) {
-		var identity = canReflect.getIdentity(props),
+	getIdentityIndex: function(compare, items, props, startIndex, schema) {
+		var identity = canReflect.getIdentity(props, schema),
 			starterItem = items[startIndex];
 		// check if the middle has a match
 		if (compare(props, starterItem) === 0) {
-			if (identity === canReflect.getIdentity(starterItem)) {
+			if (identity === canReflect.getIdentity(starterItem, schema)) {
 				return startIndex;
 			}
 		}
 		
-		var rightResult = this.getIdentityIndexByDirection(compare, items, props, startIndex+1, 1),
+		var rightResult = this.getIdentityIndexByDirection(compare, items, props, startIndex+1, 1, schema),
 			leftResult;
 		if(rightResult.index) {
 			return rightResult.index;
 		} else {
-			leftResult = this.getIdentityIndexByDirection(compare, items, props, startIndex-1, -1);
+			leftResult = this.getIdentityIndexByDirection(compare, items, props, startIndex-1, -1, schema);
 		}
 		if(leftResult.index !== undefined) {
 			return leftResult.index;
@@ -82,14 +82,14 @@ var helpers = {
 	// for a given direction (right or left)
 	// 1 for right
 	// -1 for left
-	getIdentityIndexByDirection: function(compare, items, props, startIndex, direction) {
+	getIdentityIndexByDirection: function(compare, items, props, startIndex, direction, schema) {
 		var currentIndex = startIndex;
-		var identity = canReflect.getIdentity(props);
+		var identity = canReflect.getIdentity(props, schema);
 		while(currentIndex >= 0 && currentIndex < items.length) {
 			var currentItem = items[currentIndex];
 			var computed = compare(props, currentItem);
 			if(computed === 0) {
-				if( identity === canReflect.getIdentity(currentItem)) {
+				if( identity === canReflect.getIdentity(currentItem, schema)) {
 					return {index: currentIndex};
 				}
 			} else {
@@ -100,7 +100,7 @@ var helpers = {
 		return {lastIndex: currentIndex - direction};
 	},
 	//
-	getIndex: function(compare, items, props) {
+	getIndex: function(compare, items, props, schema) {
 		if (!items || !items.length) {
 			return undefined;
 		}
@@ -121,7 +121,7 @@ var helpers = {
 				item = items[mid],
 				computed = compare(props, item);
 			if (computed === 0) {
-				return this.getIdentityIndex(compare, items, props, mid);
+				return this.getIdentityIndex(compare, items, props, mid, schema);
 			} else if (computed === -1) {
 				high = mid;
 			} else {

--- a/src/serializers/basic-query.js
+++ b/src/serializers/basic-query.js
@@ -281,7 +281,7 @@ module.exports = function(schema) {
 
 
 	// Makes a sort type that can make a compare function using the SetType
-	var Sort = BasicQuery.makeSort(keys, hydrateAndValue);
+	var Sort = BasicQuery.makeSort(schema, hydrateAndValue);
 	var serializer = new Serializer(serializeMap);
 	serializer.add(comparisonsConverter.serializer);
 

--- a/src/types/basic-query-sorting-test.js
+++ b/src/types/basic-query-sorting-test.js
@@ -356,3 +356,14 @@ QUnit.test("index uses can-reflect", function(){
     QUnit.deepEqual([obj1Read, obj2Read, itemKeyRead, itemOwnKeyRead],
         [true, true, true, true], "read everything");
 });
+
+QUnit.test(".index should work with literal objects", function() {
+	var query = new BasicQuery({
+		sort: "name"
+	});
+
+	var items = [{id: 1, name: "Item 0"}, {id: 2, name: "Item 1"}];
+	var res = query.index({id: 1, name: "Item 1"}, items);
+
+	QUnit.equal(res, 1, "Item index at 1");
+});

--- a/src/types/basic-query.js
+++ b/src/types/basic-query.js
@@ -37,7 +37,8 @@ var RecordRange = makeRealNumberRangeInclusive(0, Infinity);
 // That compare function will read the right property and return `-1` or `1`
 
 // WILL MAKE A TYPE FOR SORTING
-function makeSort(schemaKeys, hydrateAndValue) {
+function makeSort(schema, hydrateAndValue) {
+	var schemaKeys = schema.keys;
 	// Makes gt and lt functions that `helpers.sorter` can use
 	// to make a `compare` function for `Array.sort(compare)`.`
 	var sorters = {};
@@ -107,6 +108,7 @@ function makeSort(schemaKeys, hydrateAndValue) {
 
 	function Sort(key) {
 		this.key = key;
+		this.schema = schema;
 		this.compare = helpers.sorter(key, sorters);
 	}
 
@@ -129,7 +131,7 @@ function makeSort(schemaKeys, hydrateAndValue) {
 	return Sort;
 }
 
-var DefaultSort = makeSort({});
+var DefaultSort = makeSort({ keys: {}, identity: ["id"] });
 
 
 // Define the BasicQuery type
@@ -234,7 +236,7 @@ canReflect.assignMap(BasicQuery.prototype, {
 			return undefined;
 		}
 		// use the passed sort's compare function
-		return helpers.getIndex(this.sort.compare, items, props);
+		return helpers.getIndex(this.sort.compare, items, props, this.sort.schema);
 	},
 	isMember: function(props) {
 		// Use the AND type for it's isMember method


### PR DESCRIPTION
This fixes sorting literal objects (without `can@getSchema` symbol) issue by:

- Adding the `schema` to the `Sort` constructor in the `src/types/basic-query.js`
- Passing a `schema` param to the `makeSort` function
- Create `DefaultSort` constructor with a default `schema`
- Passing the `schema` to `getIndex`, `getIdentityIndex` and `getIdentityIndexByDirection` in `src/helpers.js`.

Fixes #45 