### PR TITLE
fixes ComparisonType generation

### DIFF
--- a/src/serializers/basic-query-test.js
+++ b/src/serializers/basic-query-test.js
@@ -142,7 +142,7 @@ QUnit.test("auto-convert or schema into maybe type", function(assert) {
     assert.deepEqual(res, {
         filter: {
             $or: [
-                { foo: "bar", age: {$gt: 3}},
+                { foo: "bar", age: {$gt: "3"}},
                 { foo: "bar", age: null}
             ]
         }

--- a/src/types/make-maybe.js
+++ b/src/types/make-maybe.js
@@ -238,14 +238,17 @@ makeMaybe.makeMaybeSetTypes = function(Type) {
 	} else {
 
 		ComparisonSetType = function(value) {
+			this.setValue = value;
 			this.value = canReflect.new(Type, value);
 		};
+
 		ComparisonSetType.prototype.valueOf = function() {
-			return this.value;
+			return this.value && typeof this.value.valueOf === "function" ?
+				this.value.valueOf() : this.value;
 		};
 		canReflect.assignSymbols(ComparisonSetType.prototype, {
 			"can.serialize": function() {
-				return this.value;
+				return this.setValue;
 			}
 		});
 		//!steal-remove-start


### PR DESCRIPTION
 for #57


This fixes a problem where the comparison type would return a `new Date()` instead of `.valueOf()`